### PR TITLE
[MCC-200787] 2 new options

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "http://rubygems.org"
+gem 'activesupport', '~> 3.2.22'
 gemspec
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,2 @@
 source "http://rubygems.org"
-gem 'activesupport', '~> 3.2.22'
 gemspec
-

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Rack::ContentTypeDefault is a tiny piece of middleware that sets default `CONTENT-TYPE:` header when it isn't present
 for specific requests. It checks if a content type is set and does not override the existing one.
 The options allow you to specify the request methods and the content type to be set. The options also allow you to set
-content type only for requests with certain paths. In addition, the options allow  you to set content type to
-application/xml or application/json if possible based on the path.
+content type only for requests with certain paths. In addition, the options allow  you to have content type set to
+application/xml or application/json if the path ends in .xml or .json, respectively.
 
 The code has been copied and adapted from https://gist.github.com/tstachl/6264249
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Rack::ContentTypeDefault is a tiny piece of middleware that sets default `CONTENT-TYPE:` header when it isn't present
 for specific requests. It checks if a content type is set and does not override the existing one.
 The options allow you to specify the request methods and the content type to be set. The options also allow you to set
-a default content type only on select paths. In addition, the options allow  you to set content type to to xml or json
-if possible based on the path.
+a default content type only on select paths. In addition, the options allow  you to set content type to to application/xml
+or application/json if possible based on the path.
 
 The code has been copied and adapted from https://gist.github.com/tstachl/6264249
 
@@ -35,4 +35,4 @@ config.middleware.use Rack::ContentTypeDefault, :post, 'application/json', ['/au
 ## Why
 
 It is useful if you want to make your application opinionated about the content type it expects from clients when not
-provided on some or all requests. In addition it bridges a gap between test and production environments if the clients differ.
+provided on some requests. In addition it bridges a gap between test and production environments if the clients differ.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,15 @@
 
 Rack::ContentTypeDefault is a tiny piece of middleware that sets default `CONTENT-TYPE:` header when it isn't present
 for specific requests. It checks if a content type is set and does not override the existing one.
-The options allow you to specify the request methods and the content type to be set. The options also allow you to set
-content type only for requests with certain paths. In addition, the options allow  you to have content type set to
-application/xml or application/json if the path ends in .xml or .json, respectively.
+
+The following options may be specified:
+
+1. Request method(s) on which the content type is applied. The default value is post.
+2. Desired content type. The default value is 'application/json'.
+3. Paths on which the content type is applied. The default is all paths when none are specified.
+4. A boolean value to indicate whether or not to apply 'application/xml' or 'application/json' if the path ends in .xml
+    or .json, respectively. The default value is false.
+
 
 The code has been copied and adapted from https://gist.github.com/tstachl/6264249
 

--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ config.middleware.use Rack::ContentTypeDefault, :post, 'application/json', ['/au
 ## Why
 
 It is useful if you want to make your application opinionated about the content type it expects from clients when not
-provided on some requests. In addition it bridges a gap between test and production environments if the clients differ.
+provided. In addition it bridges a gap between test and production environments if the clients differ.

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Rack::ContentTypeDefault is a tiny piece of middleware that sets default `CONTENT-TYPE:` header when it isn't present
 for specific requests. It checks if a content type is set and does not override the existing one.
 The options allow you to specify the request methods and the content type to be set. The options also allow you to set
-a default content type only on select paths. In addition, the options allow  you to set content type to to application/xml
-or application/json if possible based on the path.
+content type only for requests with certain paths. In addition, the options allow  you to set content type to
+application/xml or application/json if possible based on the path.
 
 The code has been copied and adapted from https://gist.github.com/tstachl/6264249
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Rack::ContentTypeDefault
 
 Rack::ContentTypeDefault is a tiny piece of middleware that sets default `CONTENT-TYPE:` header when it isn't present
-for specific methods. It checks if a content type is set and does not override the existing one.
-The options allow you to specify the request methods, and the content type to be set.
+for specific requests. It checks if a content type is set and does not override the existing one.
+The options allow you to specify the request methods and the content type to be set. The options also allow you to set
+a default content type only on select paths. In addition, the options allow  you to set content type to to xml or json
+if possible based on the path.
 
 The code has been copied and adapted from https://gist.github.com/tstachl/6264249
 
@@ -13,14 +15,24 @@ The code has been copied and adapted from https://gist.github.com/tstachl/626424
 TBD
 
 ## Usage
-Example:
+Examples:
 
 ```
 require 'rack/content-type-default`
 config.middleware.use Rack::ContentTypeDefault, :post, 'application/x-www-form-urlencoded'
 ```
 
+```
+require 'rack/content-type-default`
+config.middleware.use Rack::ContentTypeDefault, [:get, :post], 'application/xml', '/authenticate.xml'
+```
+
+```
+require 'rack/content-type-default`
+config.middleware.use Rack::ContentTypeDefault, :post, 'application/json', ['/authenticate.json', '/show'], true
+```
+
 ## Why
 
 It is useful if you want to make your application opinionated about the content type it expects from clients when not
-provided. In addition it bridges a gap between test and production environments if the clients differ.
+provided on some or all requests. In addition it bridges a gap between test and production environments if the clients differ.

--- a/lib/rack/content_type_default.rb
+++ b/lib/rack/content_type_default.rb
@@ -22,7 +22,7 @@ module Rack
     end
 
     private
-    # Determine whether or not to reset content type
+    # Determine whether or not to override content type
     def override_content_type?(req)
       (req.content_type.nil? || req.content_type.empty?) && match_method?(req.request_method) &&
           match_path?(req.env['PATH_INFO'])

--- a/lib/rack/content_type_default.rb
+++ b/lib/rack/content_type_default.rb
@@ -5,25 +5,25 @@
 # Copied and adapted from https://gist.github.com/tstachl/6264249
 module Rack
   class ContentTypeDefault
-    def initialize(app, methods = [:post], content_type = 'application/json', paths = 'all', default_based_on_path = false)
+    def initialize(app, methods = [:post], content_type = 'application/json', paths = 'all', use_path_hint = false)
       @app = app
       @methods = [*methods].map{ |item| item.to_s.upcase }
       @content_type = content_type
       @paths = [*paths]
-      @default_based_on_path = default_based_on_path
+      @use_path_hint = use_path_hint
     end
 
     def call(env)
       req = Rack::Request.new(env)
-      if set_content_type?(req)
-        env['CONTENT_TYPE'] = @default_based_on_path ? determine_content_type(req.env['PATH_INFO']) :  @content_type
+      if override_content_type?(req)
+        env['CONTENT_TYPE'] = @use_path_hint ? determine_content_type(req.env['PATH_INFO']) :  @content_type
       end
       @app.call(env)
     end
 
     private
     # Determine whether or not to reset content type
-    def set_content_type?(req)
+    def override_content_type?(req)
       (req.content_type.nil? || req.content_type.empty?) && match_method?(req.request_method) &&
           match_path?(req.env['PATH_INFO'])
     end
@@ -37,18 +37,15 @@ module Rack
     # Match the path on the request with the paths specified. Content type is set only if a match is found.
     # If @paths was provided with 'all' as the first element (default), content type will be set for all requests.
     # If @paths was explicitly set to empty, content type will not be set.
-    def match_path?(path_info)
-      return true if @paths.first == 'all'
-      return @paths.any? { |path| /#{path}$/.match(path_info) or /#{path}\./.match(path_info) }
-
+    def match_path?(filter)
+      @paths.first == 'all' || @paths.any? { |path| /#{path}$/.match(filter) || /#{path}\./.match(filter) }
     end
 
     #Determine if content type can be set to application/json or application/xml based on the path ending.
     #If the path does not end in xml or json, content type is set to the given default.
     def determine_content_type(path_info)
-      return 'application/xml' if path_info.split('.').last == 'xml'
-      return 'application/json' if path_info.split('.').last == 'json'
-      return @content_type
+      inferred = path_info.split('.').last
+      inferred == 'json' || inferred == 'xml' ? "application/#{inferred}" : @content_type
     end
   end
 end

--- a/lib/rack/content_type_default.rb
+++ b/lib/rack/content_type_default.rb
@@ -4,8 +4,6 @@
 # allow  you to set content type to to application/json or application/xml if possible based on the path ending.
 # Copied and adapted from https://gist.github.com/tstachl/6264249
 
-require 'active_support/core_ext'
-
 module Rack
   class ContentTypeDefault
     def initialize(app, methods = [:post], content_type = 'application/json', paths = 'all', default_based_on_path = false)
@@ -45,9 +43,10 @@ module Rack
     # If @paths was explicitly set to empty, content type will not be set.
     def match_path?(path_info)
       return true if @paths.first == 'all'
-      return @paths.any? { |path| path_info.ends_with?(path) or path_info.include?("#{path}.") }
+      return @paths.any? { |path| /#{path}$/.match(path_info) or /#{path}\./.match(path_info) }
+
     end
-    
+
     #Determine if content type can be set to application/json or application/xml based on the path ending.
     #If the path does not end in xml or json, content type is set to the given default.
     def determine_content_type(path_info)

--- a/lib/rack/content_type_default.rb
+++ b/lib/rack/content_type_default.rb
@@ -3,7 +3,7 @@
 # to be set. The options also allow you to set a default content type only on select paths. In addition, the options
 # allow  you to set content type to to application/json or application/xml if possible based on the path ending.
 # Copied and adapted from https://gist.github.com/tstachl/6264249
-
+require 'byebug'
 module Rack
   class ContentTypeDefault
     def initialize(app, methods = [:post], content_type = 'application/json', paths = 'all', default_based_on_path = false)
@@ -16,20 +16,17 @@ module Rack
 
     def call(env)
       req = Rack::Request.new(env)
-      @app.call(env) and return unless reset_content_type?(req)
-
-      env['CONTENT_TYPE'] = @default_based_on_path ? determine_content_type(req.env['PATH_INFO']) :  @content_type
+      if set_content_type?(req)
+        env['CONTENT_TYPE'] = @default_based_on_path ? determine_content_type(req.env['PATH_INFO']) :  @content_type
+      end
       @app.call(env)
     end
 
-
     private
     # Determine whether or not to reset content type
-    def reset_content_type?(req)
-      return false unless req.content_type.nil? or req.content_type.empty?
-      return false unless match_method?(req.request_method)
-      return false unless match_path?(req.env['PATH_INFO'])
-      return true
+    def set_content_type?(req)
+      (req.content_type.nil? || req.content_type.empty?) && match_method?(req.request_method) &&
+          match_path?(req.env['PATH_INFO'])
     end
 
     # Match the method on the request with the methods specified or the default.

--- a/lib/rack/content_type_default.rb
+++ b/lib/rack/content_type_default.rb
@@ -34,14 +34,12 @@ module Rack
       return true
     end
 
-    private
     # Match the method on the request with the methods specified or the default.
     # If @methods was provided as empty, content type will not be set.
     def match_method?(method)
       @methods.include?(method)
     end
 
-    private
     # Match the path on the request with the paths specified. Content type is set only if a match is found.
     # If @paths was provided with 'all' as the first element (default), content type will be set for all requests.
     # If @paths was explicitly set to empty, content type will not be set.
@@ -49,8 +47,7 @@ module Rack
       return true if @paths.first == 'all'
       return @paths.any? { |path| path_info.ends_with?(path) or path_info.include?("#{path}.") }
     end
-
-    private
+    
     #Determine if content type can be set to application/json or application/xml based on the path ending.
     #If the path does not end in xml or json, content type is set to the given default.
     def determine_content_type(path_info)

--- a/lib/rack/content_type_default.rb
+++ b/lib/rack/content_type_default.rb
@@ -3,7 +3,6 @@
 # to be set. The options also allow you to set a default content type only on select paths. In addition, the options
 # allow  you to set content type to to application/json or application/xml if possible based on the path ending.
 # Copied and adapted from https://gist.github.com/tstachl/6264249
-require 'byebug'
 module Rack
   class ContentTypeDefault
     def initialize(app, methods = [:post], content_type = 'application/json', paths = 'all', default_based_on_path = false)

--- a/lib/rack/content_type_default.rb
+++ b/lib/rack/content_type_default.rb
@@ -1,32 +1,62 @@
 # This is a simple Rack Middleware to set the request content type for specific routes. It checks if a content type is
-# set and does not override the existing one. The options allow you to specify the request methods, and the content type
-# to be set.
+# set and does not override the existing one. The options allow you to specify the request methods and the content type
+# to be set. The options also allow you to set a default content type only on select paths. In addition, the options
+# allow  you to set content type to to application/json or application/xml if possible based on the path ending.
 # Copied and adapted from https://gist.github.com/tstachl/6264249
+
+require 'active_support/core_ext'
 
 module Rack
   class ContentTypeDefault
-    def initialize(app, methods = [:post], content_type = 'application/json')
+    def initialize(app, methods = [:post], content_type = 'application/json', paths = 'all', default_based_on_path = false)
       @app = app
       @methods = [*methods].map{ |item| item.to_s.upcase }
       @content_type = content_type
+      @paths = [*paths]
+      @default_based_on_path = default_based_on_path
     end
 
     def call(env)
       req = Rack::Request.new(env)
+      @app.call(env) and return unless reset_content_type?(req)
 
-      if match_method?(req.request_method)
-        env['CONTENT_TYPE'] = @content_type if req.content_type.nil? or req.content_type.empty?
-      end
-
+      env['CONTENT_TYPE'] = @default_based_on_path ? determine_content_type(req.env['PATH_INFO']) :  @content_type
       @app.call(env)
+    end
+
+
+    private
+    # Determine whether or not to reset content type
+    def reset_content_type?(req)
+      return false unless req.content_type.nil? or req.content_type.empty?
+      return false unless match_method?(req.request_method)
+      return false unless match_path?(req.env['PATH_INFO'])
+      return true
     end
 
     private
     # Match the method on the request with the methods specified or the default.
-    # If @methods was provided as empty content type will not be set.
+    # If @methods was provided as empty, content type will not be set.
     def match_method?(method)
       @methods.include?(method)
     end
+
+    private
+    # Match the path on the request with the paths specified. Content type is set only if a match is found.
+    # If @paths was provided with 'all' as the first element (default), content type will be set for all requests.
+    # If @paths was explicitly set to empty, content type will not be set.
+    def match_path?(path_info)
+      return true if @paths.first == 'all'
+      return @paths.any? { |path| path_info.ends_with?(path) or path_info.include?("#{path}.") }
+    end
+
+    private
+    #Determine if content type can be set to application/json or application/xml based on the path ending.
+    #If the path does not end in xml or json, content type is set to the given default.
+    def determine_content_type(path_info)
+      return 'application/xml' if path_info.split('.').last == 'xml'
+      return 'application/json' if path_info.split('.').last == 'json'
+      return @content_type
+    end
   end
 end
-

--- a/spec/lib/rack/content_type_default_spec.rb
+++ b/spec/lib/rack/content_type_default_spec.rb
@@ -2,7 +2,12 @@ require 'spec_helper'
 require 'rack/mock'
 
 describe Rack::ContentTypeDefault do
-  App = lambda { |env| [200, {'Content-Type' => 'text/plain'}, env['PATH_INFO']] }
+
+  before do
+    App = lambda { |env| [200, {'Content-Type' => 'text/plain'}, env['PATH_INFO']] }
+    @post_req = Rack::MockRequest.env_for("/api/v2/customers", method: :post)
+    @get_req = Rack::MockRequest.env_for("/api/v2/customers", method: :get)
+  end
 
   context '/' do
     it 'does not set the content type on default requests' do
@@ -15,63 +20,117 @@ describe Rack::ContentTypeDefault do
 
   context 'no method explicitly specified applies to post requests only' do
     it 'sets the content type to default application/json' do
-      request  = Rack::MockRequest.env_for("/api/v2/customers", method: :post)
-      Rack::ContentTypeDefault.new(App).call(request)
-      request['CONTENT_TYPE'].should == 'application/json'
+      Rack::ContentTypeDefault.new(App).call(@post_req)
+      @post_req['CONTENT_TYPE'].should == 'application/json'
     end
 
     it 'does not override existing content type' do
-      request  = Rack::MockRequest.env_for("/api/v2/customers", method: :post)
-      request['CONTENT_TYPE'] = 'application/xml'
-      Rack::ContentTypeDefault.new(App).call(request)
-      request['CONTENT_TYPE'].should == 'application/xml'
+      @post_req['CONTENT_TYPE'] = 'application/xml'
+      Rack::ContentTypeDefault.new(App).call(@post_req)
+      @post_req['CONTENT_TYPE'].should == 'application/xml'
     end
 
     it 'does override empty content type' do
-      request  = Rack::MockRequest.env_for("/api/v2/customers", method: :post)
-      request['CONTENT_TYPE'] = ''
-      Rack::ContentTypeDefault.new(App).call(request)
-      request['CONTENT_TYPE'].should == 'application/json'
+      @post_req['CONTENT_TYPE'] = ''
+      Rack::ContentTypeDefault.new(App).call(@post_req)
+      @post_req['CONTENT_TYPE'].should == 'application/json'
     end
 
-    it 'does not the content type for get request' do
-      request  = Rack::MockRequest.env_for("/api/v2/customers", method: :get)
-      Rack::ContentTypeDefault.new(App).call(request)
-      request['CONTENT_TYPE'].should_not == 'application/json'
+    it 'does not override the content type for get request' do
+      Rack::ContentTypeDefault.new(App).call(@get_req)
+      @get_req['CONTENT_TYPE'].should_not == 'application/json'
     end
   end
 
   context 'empty methods specified applies to no requests' do
     it 'does not set content type for any method' do
-      request  = Rack::MockRequest.env_for("/api/v2/customers", method: :post)
-      Rack::ContentTypeDefault.new(App, []).call(request)
-      request['CONTENT_TYPE'].should_not == 'application/json'
+      Rack::ContentTypeDefault.new(App, []).call(@post_req)
+      @post_req['CONTENT_TYPE'].should_not == 'application/json'
     end
   end
 
   context 'method' do
     it 'allows to specify the methods' do
-      request1  = Rack::MockRequest.env_for("/api/v2/customers", method: :get)
-      request2  = Rack::MockRequest.env_for("/api/v2/customers/1", method: :post)
-      Rack::ContentTypeDefault.new(App, :get).call(request1)
-      Rack::ContentTypeDefault.new(App, :get).call(request2)
-      request1['CONTENT_TYPE'].should == 'application/json'
-      request2['CONTENT_TYPE'].should_not == 'application/json'
+      Rack::ContentTypeDefault.new(App, :get).call(@get_req)
+      Rack::ContentTypeDefault.new(App, :get).call(@post_req)
+      @get_req['CONTENT_TYPE'].should == 'application/json'
+      @post_req['CONTENT_TYPE'].should_not == 'application/json'
     end
 
     it 'may be an array' do
-      request  = Rack::MockRequest.env_for("/api/v2/customers", method: :get)
-      Rack::ContentTypeDefault.new(App, [:get, :post]).call(request)
-      request['CONTENT_TYPE'].should == 'application/json'
+      Rack::ContentTypeDefault.new(App, [:get, :post]).call(@get_req)
+      @get_req['CONTENT_TYPE'].should == 'application/json'
     end
   end
 
   context 'content type' do
     it 'allows to specify the content type' do
-      request  = Rack::MockRequest.env_for("/api/v2/customers", method: :get)
-      Rack::ContentTypeDefault.new(App, :get, 'application/xml').call(request)
-      request['CONTENT_TYPE'].should == 'application/xml'
+      Rack::ContentTypeDefault.new(App, :get, 'application/xml').call(@get_req)
+      @get_req['CONTENT_TYPE'].should == 'application/xml'
+    end
+  end
+
+  context 'paths' do
+    it 'sets the content type as appropriate if the path in the request matches one specified' do
+      @get_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.json'
+      Rack::ContentTypeDefault.new(App, :get, 'application/xml', ['/show', '/authenticate.json']).call(@get_req)
+      @get_req['CONTENT_TYPE'].should == 'application/xml'
+    end
+
+    it 'does not set a content type if the path in the request does not match any specified' do
+      @post_req['PATH_INFO'] = 'api/v2/customers/show'
+      Rack::ContentTypeDefault.new(App, [:get, :post], 'application/xml', ['/authenticate.json']).call(@post_req)
+      @post_req['CONTENT_TYPE'].should == nil
+    end
+
+    it 'sets content type as appropriate on all requests if paths specified as all' do
+      Rack::ContentTypeDefault.new(App, :get, 'application/xml', 'all').call(@get_req)
+      @get_req['CONTENT_TYPE'].should == 'application/xml'
+    end
+
+    it 'sets content type as appropriate on all requests if paths is none are explicitly specified' do
+      Rack::ContentTypeDefault.new(App, :post, 'application/xml').call(@post_req)
+      @post_req['CONTENT_TYPE'].should == 'application/xml'
+    end
+
+    it 'sets content type on no requests if paths specified as empty ' do
+      @get_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.json'
+      Rack::ContentTypeDefault.new(App, :get, 'application/xml', []).call(@get_req)
+      @get_req['CONTENT_TYPE'].should == nil
+    end
+  end
+
+  context 'default_based_on_path is set to true' do
+    it 'sets content type to application/json if path ends in .json' do
+      @post_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.json'
+      Rack::ContentTypeDefault.new(App, :post, 'application/xml', ['/authenticate.json', '/show'], true).call(@post_req)
+      @post_req['CONTENT_TYPE'].should == 'application/json'
+    end
+
+    it 'sets content type to application/xml if path ends in .xml' do
+      @get_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.xml'
+      Rack::ContentTypeDefault.new(App, [:get,:post], 'application/xml', 'all', true).call(@get_req)
+      @get_req['CONTENT_TYPE'].should == 'application/xml'
+    end
+
+    it 'sets content type to one specified if path does not end in .json or .xml' do
+      @post_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.pdf'
+      Rack::ContentTypeDefault.new(App, :post, 'application/xml', 'all', true).call(@post_req)
+      @post_req['CONTENT_TYPE'].should == 'application/xml'
+    end
+  end
+
+  context 'default_based_on_path is set to false' do
+    it 'does not set content type based on path ending if argument explicitly set to false' do
+      @get_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.json'
+      Rack::ContentTypeDefault.new(App, :get, 'application/xml', '/authenticate.json', false).call(@get_req)
+      @get_req['CONTENT_TYPE'].should == 'application/xml'
+    end
+
+    it 'does not set content type based on path ending if no argument explicitly specified' do
+      @post_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.json'
+      Rack::ContentTypeDefault.new(App, :post, 'application/xml', '/authenticate.json').call(@post_req)
+      @post_req['CONTENT_TYPE'].should == 'application/xml'
     end
   end
 end
-

--- a/spec/lib/rack/content_type_default_spec.rb
+++ b/spec/lib/rack/content_type_default_spec.rb
@@ -2,11 +2,9 @@ require 'spec_helper'
 require 'rack/mock'
 
 describe Rack::ContentTypeDefault do
-  before do
-    App = lambda { |env| [200, {'Content-Type' => 'text/plain'}, env['PATH_INFO']] }
-    @post_req = Rack::MockRequest.env_for("/api/v2/customers", method: :post)
-    @get_req = Rack::MockRequest.env_for("/api/v2/customers", method: :get)
-  end
+  App = lambda { |env| [200, {'Content-Type' => 'text/plain'}, env['PATH_INFO']] }
+  let(:post_req) { Rack::MockRequest.env_for("/api/v2/customers", method: :post) }
+  let(:get_req)     { Rack::MockRequest.env_for("/api/v2/customers", method: :get) }
 
   context '/' do
     it 'does not set the content type on default requests' do
@@ -19,117 +17,117 @@ describe Rack::ContentTypeDefault do
 
   context 'no method explicitly specified applies to post requests only' do
     it 'sets the content type to default application/json' do
-      Rack::ContentTypeDefault.new(App).call(@post_req)
-      @post_req['CONTENT_TYPE'].should == 'application/json'
+      Rack::ContentTypeDefault.new(App).call(post_req)
+      post_req['CONTENT_TYPE'].should == 'application/json'
     end
 
     it 'does not override existing content type' do
-      @post_req['CONTENT_TYPE'] = 'application/xml'
-      Rack::ContentTypeDefault.new(App).call(@post_req)
-      @post_req['CONTENT_TYPE'].should == 'application/xml'
+      post_req['CONTENT_TYPE'] = 'application/xml'
+      Rack::ContentTypeDefault.new(App).call(post_req)
+      post_req['CONTENT_TYPE'].should == 'application/xml'
     end
 
     it 'does override empty content type' do
-      @post_req['CONTENT_TYPE'] = ''
-      Rack::ContentTypeDefault.new(App).call(@post_req)
-      @post_req['CONTENT_TYPE'].should == 'application/json'
+      post_req['CONTENT_TYPE'] = ''
+      Rack::ContentTypeDefault.new(App).call(post_req)
+      post_req['CONTENT_TYPE'].should == 'application/json'
     end
 
     it 'does not override the content type for get request' do
-      Rack::ContentTypeDefault.new(App).call(@get_req)
-      @get_req['CONTENT_TYPE'].should_not == 'application/json'
+      Rack::ContentTypeDefault.new(App).call(get_req)
+      get_req['CONTENT_TYPE'].should_not == 'application/json'
     end
   end
 
   context 'empty methods specified applies to no requests' do
     it 'does not set content type for any method' do
-      Rack::ContentTypeDefault.new(App, []).call(@post_req)
-      @post_req['CONTENT_TYPE'].should_not == 'application/json'
+      Rack::ContentTypeDefault.new(App, []).call(post_req)
+      post_req['CONTENT_TYPE'].should_not == 'application/json'
     end
   end
 
   context 'method' do
     it 'allows to specify the methods' do
-      Rack::ContentTypeDefault.new(App, :get).call(@get_req)
-      Rack::ContentTypeDefault.new(App, :get).call(@post_req)
-      @get_req['CONTENT_TYPE'].should == 'application/json'
-      @post_req['CONTENT_TYPE'].should_not == 'application/json'
+      Rack::ContentTypeDefault.new(App, :get).call(get_req)
+      Rack::ContentTypeDefault.new(App, :get).call(post_req)
+      get_req['CONTENT_TYPE'].should == 'application/json'
+      post_req['CONTENT_TYPE'].should_not == 'application/json'
     end
 
     it 'may be an array' do
-      Rack::ContentTypeDefault.new(App, [:get, :post]).call(@get_req)
-      @get_req['CONTENT_TYPE'].should == 'application/json'
+      Rack::ContentTypeDefault.new(App, [:get, :post]).call(get_req)
+      get_req['CONTENT_TYPE'].should == 'application/json'
     end
   end
 
   context 'content type' do
     it 'allows to specify the content type' do
-      Rack::ContentTypeDefault.new(App, :get, 'application/xml').call(@get_req)
-      @get_req['CONTENT_TYPE'].should == 'application/xml'
+      Rack::ContentTypeDefault.new(App, :get, 'application/xml').call(get_req)
+      get_req['CONTENT_TYPE'].should == 'application/xml'
     end
   end
 
   context 'paths' do
     it 'sets the content type as appropriate if the path in the request matches one specified' do
-      @get_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.json'
-      Rack::ContentTypeDefault.new(App, :get, 'application/xml', ['/show', '/authenticate.json']).call(@get_req)
-      @get_req['CONTENT_TYPE'].should == 'application/xml'
+      get_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.json'
+      Rack::ContentTypeDefault.new(App, :get, 'application/xml', ['/show', '/authenticate.json']).call(get_req)
+      get_req['CONTENT_TYPE'].should == 'application/xml'
     end
 
     it 'does not set a content type if the path in the request does not match any specified' do
-      @post_req['PATH_INFO'] = 'api/v2/customers/show'
-      Rack::ContentTypeDefault.new(App, [:get, :post], 'application/xml', ['/authenticate.json']).call(@post_req)
-      @post_req['CONTENT_TYPE'].should == nil
+      post_req['PATH_INFO'] = 'api/v2/customers/show'
+      Rack::ContentTypeDefault.new(App, [:get, :post], 'application/xml', ['/authenticate.json']).call(post_req)
+      post_req['CONTENT_TYPE'].should == nil
     end
 
     it 'sets content type as appropriate on all requests if paths specified as all' do
-      Rack::ContentTypeDefault.new(App, :get, 'application/xml', 'all').call(@get_req)
-      @get_req['CONTENT_TYPE'].should == 'application/xml'
+      Rack::ContentTypeDefault.new(App, :get, 'application/xml', 'all').call(get_req)
+      get_req['CONTENT_TYPE'].should == 'application/xml'
     end
 
     it 'sets content type as appropriate on all requests if paths is none are explicitly specified' do
-      Rack::ContentTypeDefault.new(App, :post, 'application/xml').call(@post_req)
-      @post_req['CONTENT_TYPE'].should == 'application/xml'
+      Rack::ContentTypeDefault.new(App, :post, 'application/xml').call(post_req)
+      post_req['CONTENT_TYPE'].should == 'application/xml'
     end
 
     it 'sets content type on no requests if paths specified as empty ' do
-      @get_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.json'
-      Rack::ContentTypeDefault.new(App, :get, 'application/xml', []).call(@get_req)
-      @get_req['CONTENT_TYPE'].should == nil
+      get_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.json'
+      Rack::ContentTypeDefault.new(App, :get, 'application/xml', []).call(get_req)
+      get_req['CONTENT_TYPE'].should == nil
     end
   end
 
   context 'default_based_on_path is set to true' do
     it 'sets content type to application/json if path ends in .json' do
-      @post_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.json'
-      Rack::ContentTypeDefault.new(App, :post, 'application/xml', ['/authenticate.json', '/show'], true).call(@post_req)
-      @post_req['CONTENT_TYPE'].should == 'application/json'
+      post_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.json'
+      Rack::ContentTypeDefault.new(App, :post, 'application/xml', ['/authenticate.json', '/show'], true).call(post_req)
+      post_req['CONTENT_TYPE'].should == 'application/json'
     end
 
     it 'sets content type to application/xml if path ends in .xml' do
-      @get_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.xml'
-      Rack::ContentTypeDefault.new(App, [:get,:post], 'application/xml', 'all', true).call(@get_req)
-      @get_req['CONTENT_TYPE'].should == 'application/xml'
+      get_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.xml'
+      Rack::ContentTypeDefault.new(App, [:get,:post], 'application/xml', 'all', true).call(get_req)
+      get_req['CONTENT_TYPE'].should == 'application/xml'
     end
 
     it 'sets content type to one specified if path does not end in .json or .xml' do
-      @post_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.pdf'
-      Rack::ContentTypeDefault.new(App, :post, 'application/xml', 'all', true).call(@post_req)
-      @post_req['CONTENT_TYPE'].should == 'application/xml'
+      post_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.pdf'
+      Rack::ContentTypeDefault.new(App, :post, 'application/xml', 'all', true).call(post_req)
+      post_req['CONTENT_TYPE'].should == 'application/xml'
     end
   end
 
   context 'default_based_on_path is set to false' do
     it 'does not set content type based on path ending if argument explicitly set to false' do
-      @get_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.json'
-      Rack::ContentTypeDefault.new(App, :get, 'application/xml', '/authenticate.json', false).call(@get_req)
-      @get_req['CONTENT_TYPE'].should == 'application/xml'
+      get_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.json'
+      Rack::ContentTypeDefault.new(App, :get, 'application/xml', '/authenticate.json', false).call(get_req)
+      get_req['CONTENT_TYPE'].should == 'application/xml'
     end
 
     it 'does not set content type based on path ending if no argument explicitly specified' do
-      @post_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.json'
-      Rack::ContentTypeDefault.new(App, :post, 'application/xml', '/authenticate.json').call(@post_req)
-      @post_req['CONTENT_TYPE'].should == 'application/xml'
+      post_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.json'
+      Rack::ContentTypeDefault.new(App, :post, 'application/xml', '/authenticate.json').call(post_req)
+      post_req['CONTENT_TYPE'].should == 'application/xml'
     end
   end
 end

--- a/spec/lib/rack/content_type_default_spec.rb
+++ b/spec/lib/rack/content_type_default_spec.rb
@@ -69,9 +69,9 @@ describe Rack::ContentTypeDefault do
 
   context 'paths' do
     it 'sets the content type as appropriate if the path in the request matches one specified' do
-      get_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.json'
-      Rack::ContentTypeDefault.new(App, :get, 'application/xml', ['/show', '/authenticate.json']).call(get_req)
-      get_req['CONTENT_TYPE'].should == 'application/xml'
+      post_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.json'
+      Rack::ContentTypeDefault.new(App, :post, 'application/xml', ['/show', '/authenticate.json']).call(post_req)
+      post_req['CONTENT_TYPE'].should == 'application/xml'
     end
 
     it 'does not set a content type if the path in the request does not match any specified' do
@@ -85,7 +85,7 @@ describe Rack::ContentTypeDefault do
       get_req['CONTENT_TYPE'].should == 'application/xml'
     end
 
-    it 'sets content type as appropriate on all requests if paths is none are explicitly specified' do
+    it 'sets content type as appropriate on all requests by default since no paths specified defaults to all paths' do
       Rack::ContentTypeDefault.new(App, :post, 'application/xml').call(post_req)
       post_req['CONTENT_TYPE'].should == 'application/xml'
     end
@@ -97,8 +97,8 @@ describe Rack::ContentTypeDefault do
     end
   end
 
-  context 'default_based_on_path is set to true' do
-    it 'sets content type to application/json if path ends in .json' do
+  context 'use_path_hint is set to true' do
+    it 'overrides content type to application/json if path ends in .json' do
       post_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.json'
       Rack::ContentTypeDefault.new(App, :post, 'application/xml', ['/authenticate', '/show'], true).call(post_req)
       post_req['CONTENT_TYPE'].should == 'application/json'
@@ -117,7 +117,7 @@ describe Rack::ContentTypeDefault do
     end
   end
 
-  context 'default_based_on_path is set to false' do
+  context 'use_path_hint is set to false' do
     it 'does not set content type based on path ending if argument explicitly set to false' do
       get_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.json'
       Rack::ContentTypeDefault.new(App, :get, 'application/xml', '/authenticate.json', false).call(get_req)

--- a/spec/lib/rack/content_type_default_spec.rb
+++ b/spec/lib/rack/content_type_default_spec.rb
@@ -90,7 +90,7 @@ describe Rack::ContentTypeDefault do
       post_req['CONTENT_TYPE'].should == 'application/xml'
     end
 
-    it 'sets content type on no requests if paths specified as empty ' do
+    it 'does not set content type on any requests if paths specified as empty ' do
       get_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.json'
       Rack::ContentTypeDefault.new(App, :get, 'application/xml', []).call(get_req)
       get_req['CONTENT_TYPE'].should == nil
@@ -100,7 +100,7 @@ describe Rack::ContentTypeDefault do
   context 'default_based_on_path is set to true' do
     it 'sets content type to application/json if path ends in .json' do
       post_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.json'
-      Rack::ContentTypeDefault.new(App, :post, 'application/xml', ['/authenticate.json', '/show'], true).call(post_req)
+      Rack::ContentTypeDefault.new(App, :post, 'application/xml', ['/authenticate', '/show'], true).call(post_req)
       post_req['CONTENT_TYPE'].should == 'application/json'
     end
 

--- a/spec/lib/rack/content_type_default_spec.rb
+++ b/spec/lib/rack/content_type_default_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 require 'rack/mock'
 
 describe Rack::ContentTypeDefault do
-
   before do
     App = lambda { |env| [200, {'Content-Type' => 'text/plain'}, env['PATH_INFO']] }
     @post_req = Rack::MockRequest.env_for("/api/v2/customers", method: :post)


### PR DESCRIPTION
Rack::ContentTypeDefault is a piece of middleware that sets default `CONTENT-TYPE:` header when it isn't present. It checks if a content type is set and does not override the existing one.  Currently, the options allow you to specify the request methods and the content type to be set. So for example, you can decide to set the content-type to 'application/x-www-form-urlencoded' on post requests if one is not provided.

The purpose of this PR is to add two new options for the user without breaking existing functionality. iMedidata will take advantage of these new options in order to set content type if none is provided by the API consumer for requests made via the authenticate route.

@pmavinkurve-mdsol @cwhite-mdsol @sakhtermdsol @fpcyan @njacobs1 

New option 1: The user can decide to set the content type (if one is not provided) only for requests with certain paths. So for example, specifying "authenticate" would only set content type for requests with paths ending in "/authenticate". The user can specify 1, multiple, or all paths. If nothing is specified, the default is that there is no path validation required (ie, that all paths are specified). 

New option 2: The user has the option to have content type set to application/xml or application/json if the path ends with .xml or .json, respectively. If the path ends in neither, the content type is set to the one specified by the user. The default behavior (when the option isn't explicitly exercised) is not to determine content type based on path ending at all, but rather to always set content type to the one specified by the user.

iMedidata will use these two new options to set content type for authentication requests made via the authenticate route with the following:

config.middleware.use Rack::ContentTypeDefault, [:get, :post], 'application/json', 'authenticate', true
 
rspec
Finished in 0.00749 seconds (files took 0.1922 seconds to load)
19 examples, 0 failures