### PR TITLE
refresh the gem and publish to rubygems.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+dist: focal
+language: ruby
+cache: bundler
+
+rvm:
+  - 2.5
+  - 2.6
+  - 2.7
+  - 3.0
+
+before_install:
+  - gem update --system --force -N > /dev/null && echo "Rubygems version $(gem --version)"
+  - gem install bundler --force -N && bundle --version
+
+install: BUNDLE_JOBS=4 bundle install
+
+script: bundle exec rspec
+
+deploy:
+  edge: true # opt in to dpl v2
+  provider: rubygems
+  on:
+    tags: true
+    condition: $TRAVIS_RUBY_VERSION == 3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# 1.0.0
+- Refresh code/specs and publish to rubygems.org.
+
+# 0.0.0
+- Initial release.

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,5 @@
-source "http://rubygems.org"
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
 gemspec

--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014 Medidata Solutions Worldwide
+Copyright (c) 2014-2021 Medidata Solutions Worldwide
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -16,25 +16,28 @@ The code has been copied and adapted from https://gist.github.com/tstachl/626424
 
 ## Installation
 
-### rubygems
+Add the following line to your application's Gemfile:
 
-TBD
+```ruby
+gem 'rack_content_type_default', '~> 1.0'
+```
 
 ## Usage
+
 Examples:
 
-```
-require 'rack/content-type-default`
+```ruby
+require 'rack/content-type-default'
 config.middleware.use Rack::ContentTypeDefault, :post, 'application/x-www-form-urlencoded'
 ```
 
-```
-require 'rack/content-type-default`
+```ruby
+require 'rack/content-type-default'
 config.middleware.use Rack::ContentTypeDefault, [:get, :post], 'application/xml', '/authenticate.xml'
 ```
 
-```
-require 'rack/content-type-default`
+```ruby
+require 'rack/content-type-default'
 config.middleware.use Rack::ContentTypeDefault, :post, 'application/json', ['/authenticate.json', '/show'], true
 ```
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,8 @@
-#!/usr/bin/env rake
-begin
-  require 'bundler/setup'
-  require 'bundler/gem_tasks'
-rescue LoadError
-  raise 'You must `gem install bundler` and `bundle install` to run rake tasks'
-end
+# frozen_string_literal: true
 
+require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
+
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec

--- a/lib/rack/content_type_default.rb
+++ b/lib/rack/content_type_default.rb
@@ -7,7 +7,7 @@ module Rack
   class ContentTypeDefault
     def initialize(app, methods = [:post], content_type = 'application/json', paths = 'all', use_path_hint = false)
       @app = app
-      @methods = [*methods].map{ |item| item.to_s.upcase }
+      @methods = [*methods].map { |item| item.to_s.upcase }
       @content_type = content_type
       @paths = [*paths]
       @use_path_hint = use_path_hint
@@ -16,16 +16,17 @@ module Rack
     def call(env)
       req = Rack::Request.new(env)
       if override_content_type?(req)
-        env['CONTENT_TYPE'] = @use_path_hint ? determine_content_type(req.env['PATH_INFO']) :  @content_type
+        env['CONTENT_TYPE'] = @use_path_hint ? determine_content_type(req.env['PATH_INFO']) : @content_type
       end
       @app.call(env)
     end
 
     private
+
     # Determine whether or not to override content type
     def override_content_type?(req)
       (req.content_type.nil? || req.content_type.empty?) && match_method?(req.request_method) &&
-          match_path?(req.env['PATH_INFO'])
+        match_path?(req.env['PATH_INFO'])
     end
 
     # Match the method on the request with the methods specified or the default.
@@ -38,14 +39,14 @@ module Rack
     # If @paths was provided with 'all' as the first element (default), content type will be set for all requests.
     # If @paths was explicitly set to empty, content type will not be set.
     def match_path?(filter)
-      @paths.first == 'all' || @paths.any? { |path| /#{path}$/.match(filter) || /#{path}\./.match(filter) }
+      @paths.first == 'all' || @paths.any? { |path| /#{path}$/.match?(filter) || /#{path}\./.match?(filter) }
     end
 
-    #Determine if content type can be set to application/json or application/xml based on the path ending.
-    #If the path does not end in xml or json, content type is set to the given default.
+    # Determine if content type can be set to application/json or application/xml based on the path ending.
+    # If the path does not end in xml or json, content type is set to the given default.
     def determine_content_type(path_info)
       inferred = path_info.split('.').last
-      inferred == 'json' || inferred == 'xml' ? "application/#{inferred}" : @content_type
+      %w[json xml].include?(inferred) ? "application/#{inferred}" : @content_type
     end
   end
 end

--- a/lib/rack/content_type_default/version.rb
+++ b/lib/rack/content_type_default/version.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module Rack
   class ContentTypeDefault
-    VERSION = '0.0.0'
+    VERSION = '1.0.0'
   end
 end

--- a/rack_content_type_default.gemspec
+++ b/rack_content_type_default.gemspec
@@ -1,26 +1,26 @@
-lib = File.expand_path('../lib/', __FILE__)
-$:.unshift lib unless $:.include?(lib)
+# frozen_string_literal: true
 
-require 'rack/content_type_default/version'
+require_relative 'lib/rack/content_type_default/version'
 
 Gem::Specification.new do |s|
-  s.name                      = 'rack_content_type_default'
-  s.version                   = Rack::ContentTypeDefault::VERSION
-  s.authors                   = ['Purnima Mavinkurve', 'Connor Savage']
-  s.email                     = ['pmavinkurve@mdsol.com', 'csavage@mdsol.com']
-  s.homepage                  = 'https://github.com/pmavinkurve-mdsol/rack_content_type_default'
-  s.summary                   = 'Rack Middleware for setting content type when not provided' 
-  s.description               = 'Rack Middleware for setting content type when not provided'
+  s.name                  = 'rack_content_type_default'
+  s.version               = Rack::ContentTypeDefault::VERSION
+  s.authors               = ['Purnima Mavinkurve', 'Connor Savage']
+  s.email                 = ['pmavinkurve@mdsol.com']
+  s.homepage              = 'https://github.com/mdsol/rack_content_type_default'
+  s.summary               = 'Rack Middleware for setting content type when not provided'
+  s.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
 
-  s.required_rubygems_version = ">= 1.3.5"
-
-  s.files                     = Dir.glob("{lib}/**/*")
-  s.require_path              = 'lib'
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  s.files = Dir.chdir(File.expand_path(__dir__)) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:test|spec|features)/}) }
+  end
+  s.require_paths = ['lib']
 
   s.add_runtime_dependency 'rack'
 
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'rspec'
-  s.add_development_dependency('debugger', '~> 1.6.0')
-  s.add_development_dependency('simplecov')
+  s.add_development_dependency 'simplecov'
 end

--- a/spec/lib/rack/content_type_default_spec.rb
+++ b/spec/lib/rack/content_type_default_spec.rb
@@ -1,133 +1,135 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'rack/mock'
 
-describe Rack::ContentTypeDefault do
-  App = lambda { |env| [200, {'Content-Type' => 'text/plain'}, env['PATH_INFO']] }
-  let(:post_req) { Rack::MockRequest.env_for("/api/v2/customers", method: :post) }
-  let(:get_req)     { Rack::MockRequest.env_for("/api/v2/customers", method: :get) }
+RSpec.describe Rack::ContentTypeDefault do
+  let(:app) { ->(env) { [200, { 'Content-Type' => 'text/plain' }, env['PATH_INFO']] } }
+  let(:post_req) { Rack::MockRequest.env_for('/api/v2/customers', method: :post) }
+  let(:get_req) { Rack::MockRequest.env_for('/api/v2/customers', method: :get) }
 
   context '/' do
     it 'does not set the content type on default requests' do
-      request  = Rack::MockRequest.env_for("/")
+      request = Rack::MockRequest.env_for('/')
       request['CONTENT_TYPE'] = 'text/plain'
-      Rack::ContentTypeDefault.new(App).call(request)
-      request['CONTENT_TYPE'].should == 'text/plain'
+      Rack::ContentTypeDefault.new(app).call(request)
+      expect(request['CONTENT_TYPE']).to eq('text/plain')
     end
   end
 
   context 'no method explicitly specified applies to post requests only' do
     it 'sets the content type to default application/json' do
-      Rack::ContentTypeDefault.new(App).call(post_req)
-      post_req['CONTENT_TYPE'].should == 'application/json'
+      Rack::ContentTypeDefault.new(app).call(post_req)
+      expect(post_req['CONTENT_TYPE']).to eq('application/json')
     end
 
     it 'does not override existing content type' do
       post_req['CONTENT_TYPE'] = 'application/xml'
-      Rack::ContentTypeDefault.new(App).call(post_req)
-      post_req['CONTENT_TYPE'].should == 'application/xml'
+      Rack::ContentTypeDefault.new(app).call(post_req)
+      expect(post_req['CONTENT_TYPE']).to eq('application/xml')
     end
 
     it 'does override empty content type' do
       post_req['CONTENT_TYPE'] = ''
-      Rack::ContentTypeDefault.new(App).call(post_req)
-      post_req['CONTENT_TYPE'].should == 'application/json'
+      Rack::ContentTypeDefault.new(app).call(post_req)
+      expect(post_req['CONTENT_TYPE']).to eq('application/json')
     end
 
     it 'does not override the content type for get request' do
-      Rack::ContentTypeDefault.new(App).call(get_req)
-      get_req['CONTENT_TYPE'].should_not == 'application/json'
+      Rack::ContentTypeDefault.new(app).call(get_req)
+      expect(get_req['CONTENT_TYPE']).not_to eq('application/json')
     end
   end
 
   context 'empty methods specified applies to no requests' do
     it 'does not set content type for any method' do
-      Rack::ContentTypeDefault.new(App, []).call(post_req)
-      post_req['CONTENT_TYPE'].should_not == 'application/json'
+      Rack::ContentTypeDefault.new(app, []).call(post_req)
+      expect(post_req['CONTENT_TYPE']).not_to eq('application/json')
     end
   end
 
   context 'method' do
     it 'allows to specify the methods' do
-      Rack::ContentTypeDefault.new(App, :get).call(get_req)
-      Rack::ContentTypeDefault.new(App, :get).call(post_req)
-      get_req['CONTENT_TYPE'].should == 'application/json'
-      post_req['CONTENT_TYPE'].should_not == 'application/json'
+      Rack::ContentTypeDefault.new(app, :get).call(get_req)
+      Rack::ContentTypeDefault.new(app, :get).call(post_req)
+      expect(get_req['CONTENT_TYPE']).to eq('application/json')
+      expect(post_req['CONTENT_TYPE']).not_to eq('application/json')
     end
 
     it 'may be an array' do
-      Rack::ContentTypeDefault.new(App, [:get, :post]).call(get_req)
-      get_req['CONTENT_TYPE'].should == 'application/json'
+      Rack::ContentTypeDefault.new(app, %i[get post]).call(get_req)
+      expect(get_req['CONTENT_TYPE']).to eq('application/json')
     end
   end
 
   context 'content type' do
     it 'allows to specify the content type' do
-      Rack::ContentTypeDefault.new(App, :get, 'application/xml').call(get_req)
-      get_req['CONTENT_TYPE'].should == 'application/xml'
+      Rack::ContentTypeDefault.new(app, :get, 'application/xml').call(get_req)
+      expect(get_req['CONTENT_TYPE']).to eq('application/xml')
     end
   end
 
   context 'paths' do
     it 'sets the content type as appropriate if the path in the request matches one specified' do
       post_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.json'
-      Rack::ContentTypeDefault.new(App, :post, 'application/xml', ['/show', '/authenticate.json']).call(post_req)
-      post_req['CONTENT_TYPE'].should == 'application/xml'
+      Rack::ContentTypeDefault.new(app, :post, 'application/xml', ['/show', '/authenticate.json']).call(post_req)
+      expect(post_req['CONTENT_TYPE']).to eq('application/xml')
     end
 
     it 'does not set a content type if the path in the request does not match any specified' do
       post_req['PATH_INFO'] = 'api/v2/customers/show'
-      Rack::ContentTypeDefault.new(App, [:get, :post], 'application/xml', ['/authenticate.json']).call(post_req)
-      post_req['CONTENT_TYPE'].should == nil
+      Rack::ContentTypeDefault.new(app, %i[get post], 'application/xml', ['/authenticate.json']).call(post_req)
+      expect(post_req['CONTENT_TYPE']).to eq(nil)
     end
 
     it 'sets content type as appropriate on all requests if paths specified as all' do
-      Rack::ContentTypeDefault.new(App, :get, 'application/xml', 'all').call(get_req)
-      get_req['CONTENT_TYPE'].should == 'application/xml'
+      Rack::ContentTypeDefault.new(app, :get, 'application/xml', 'all').call(get_req)
+      expect(get_req['CONTENT_TYPE']).to eq('application/xml')
     end
 
     it 'sets content type as appropriate on all requests by default since no paths specified defaults to all paths' do
-      Rack::ContentTypeDefault.new(App, :post, 'application/xml').call(post_req)
-      post_req['CONTENT_TYPE'].should == 'application/xml'
+      Rack::ContentTypeDefault.new(app, :post, 'application/xml').call(post_req)
+      expect(post_req['CONTENT_TYPE']).to eq('application/xml')
     end
 
     it 'does not set content type on any requests if paths specified as empty ' do
       get_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.json'
-      Rack::ContentTypeDefault.new(App, :get, 'application/xml', []).call(get_req)
-      get_req['CONTENT_TYPE'].should == nil
+      Rack::ContentTypeDefault.new(app, :get, 'application/xml', []).call(get_req)
+      expect(get_req['CONTENT_TYPE']).to eq(nil)
     end
   end
 
   context 'use_path_hint is set to true' do
     it 'overrides content type to application/json if path ends in .json' do
       post_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.json'
-      Rack::ContentTypeDefault.new(App, :post, 'application/xml', ['/authenticate', '/show'], true).call(post_req)
-      post_req['CONTENT_TYPE'].should == 'application/json'
+      Rack::ContentTypeDefault.new(app, :post, 'application/xml', ['/authenticate', '/show'], true).call(post_req)
+      expect(post_req['CONTENT_TYPE']).to eq('application/json')
     end
 
     it 'sets content type to application/xml if path ends in .xml' do
       get_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.xml'
-      Rack::ContentTypeDefault.new(App, [:get,:post], 'application/xml', 'all', true).call(get_req)
-      get_req['CONTENT_TYPE'].should == 'application/xml'
+      Rack::ContentTypeDefault.new(app, %i[get post], 'application/xml', 'all', true).call(get_req)
+      expect(get_req['CONTENT_TYPE']).to eq('application/xml')
     end
 
     it 'sets content type to one specified if path does not end in .json or .xml' do
       post_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.pdf'
-      Rack::ContentTypeDefault.new(App, :post, 'application/xml', 'all', true).call(post_req)
-      post_req['CONTENT_TYPE'].should == 'application/xml'
+      Rack::ContentTypeDefault.new(app, :post, 'application/xml', 'all', true).call(post_req)
+      expect(post_req['CONTENT_TYPE']).to eq('application/xml')
     end
   end
 
   context 'use_path_hint is set to false' do
     it 'does not set content type based on path ending if argument explicitly set to false' do
       get_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.json'
-      Rack::ContentTypeDefault.new(App, :get, 'application/xml', '/authenticate.json', false).call(get_req)
-      get_req['CONTENT_TYPE'].should == 'application/xml'
+      Rack::ContentTypeDefault.new(app, :get, 'application/xml', '/authenticate.json', false).call(get_req)
+      expect(get_req['CONTENT_TYPE']).to eq('application/xml')
     end
 
     it 'does not set content type based on path ending if no argument explicitly specified' do
       post_req['PATH_INFO'] = 'api/v2/customers/2155/authenticate.json'
-      Rack::ContentTypeDefault.new(App, :post, 'application/xml', '/authenticate.json').call(post_req)
-      post_req['CONTENT_TYPE'].should == 'application/xml'
+      Rack::ContentTypeDefault.new(app, :post, 'application/xml', '/authenticate.json').call(post_req)
+      expect(post_req['CONTENT_TYPE']).to eq('application/xml')
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,13 @@
+# frozen_string_literal: true
+
 require 'simplecov'
 SimpleCov.start
 
-require 'rspec'
-require 'debugger'
 require 'rack/content_type_default'
+require 'rspec'
 
 RSpec.configure do |config|
-#  config.mock_with :rspec
+  config.disable_monkey_patching!
+
+  Kernel.srand config.seed
 end


### PR DESCRIPTION
Self explanatory I guess. I added the necessary token so it publishes to rubygems.org. Finally we'll be able to simply reference the gem, without using the github source.

Note I "refactored" the code using transpec and rubocop. I added the magic frozen comments except on the (single) source code file because I wasn't sure whether that'd cause breakage and if the specs were covering this properly.