### PR TITLE
bump version since v1.0.0 had already been tagged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-# 1.0.0
+# 1.1.0
 - Refresh code/specs and publish to rubygems.org.
 
-# 0.0.0
+# 0.0.0 (tagged `v1.0.0`)
 - Initial release.

--- a/lib/rack/content_type_default/version.rb
+++ b/lib/rack/content_type_default/version.rb
@@ -2,6 +2,6 @@
 
 module Rack
   class ContentTypeDefault
-    VERSION = '1.0.0'
+    VERSION = '1.1.0'
   end
 end


### PR DESCRIPTION
Sorry I hadn't noticed that `v1.0.0` had already been tagged (even though the gem version was still `0.0.0`... 😨).

This bumps to 1.1.0 so we can have a clean version cut.

Afterwards I'll open a develop → master PR and tag once it's merged.

@pmavinkurve-mdsol 